### PR TITLE
Remove assertion as 'userError' can be NULL

### DIFF
--- a/templates/authenticate.php
+++ b/templates/authenticate.php
@@ -7,7 +7,6 @@
  */
 assert('is_array($this->data["formData"])');
 assert('is_string($this->data["formPost"])');
-assert('is_string($this->data["userError"])');
 
 $this->data['head']  = '<link rel="stylesheet" type="text/css" href="/' .
     $this->data['baseurlpath'] . 'module.php/simpletotp/style.css" />' . "\n";


### PR DESCRIPTION
Resolves the following error: 

`SimpleSAML_Error_Assertion: Assertion failed: 'is_string($this->data["userError"])'`

`templates/authenticate.php` checks if this value is_null on L23, so seems odd there's an is_string assertion.